### PR TITLE
Fix: Couldn't set activeCrumbStyle via props

### DIFF
--- a/src/breadcrumb.js
+++ b/src/breadcrumb.js
@@ -14,14 +14,14 @@ const COLOR = '#e52b50';
 const TEXT_COLOR = 'black';
 const DISABLE_TEXT_COLOR = 'grey'
 
-const Crumb = ({ isCrumbActive, index, text, firstCrumbStyle, lastCrumbStyle, crumbStyle, activeTabStyle, crumbTextStyle, activeCrumbTextStyle,
+const Crumb = ({ isCrumbActive, index, text, firstCrumbStyle, lastCrumbStyle, crumbStyle, activeCrumbStyle, crumbTextStyle, activeCrumbTextStyle,
   onCrumbPress, height, triangleHeadStyle, triangleTailStyle }) => {
   return (
     <TouchableOpacity
       style={[
         styles.crumbStyle,
         crumbStyle,
-        isCrumbActive ? [styles.activeCrumbStyle, activeTabStyle] : {},
+        isCrumbActive ? [styles.activeCrumbStyle, activeCrumbStyle] : {},
         firstCrumbStyle,
         lastCrumbStyle,
         { height }]}


### PR DESCRIPTION
I want set the background color via the activeCrumbStyle prop:
```
<Breadcrumb
    entities={entities}
    isTouchable={true}
    flowDepth={entities.length - 1}
    onCrumbPress={index => actions[index]()}
    activeCrumbStyle={{backgroundColor: '#007aff'}}
/>
```